### PR TITLE
fix(db): 重构数据访问层的租户策略忽略逻辑|自动释放本地忽略策略

### DIFF
--- a/wemirr-platform-framework/db-spring-boot-starter/src/main/java/com/wemirr/framework/db/utils/InterceptorIgnoreUtils.java
+++ b/wemirr-platform-framework/db-spring-boot-starter/src/main/java/com/wemirr/framework/db/utils/InterceptorIgnoreUtils.java
@@ -1,0 +1,25 @@
+package com.wemirr.framework.db.utils;
+
+import com.baomidou.mybatisplus.core.plugins.IgnoreStrategy;
+import com.baomidou.mybatisplus.core.plugins.InterceptorIgnoreHelper;
+
+import java.util.function.Supplier;
+
+/**
+ * @author YanCh
+ * Created on: 2025-04-09 13:31
+ **/
+public class InterceptorIgnoreUtils {
+    public static <T> T withIgnoreStrategy(Supplier<T> block) {
+        return withIgnoreStrategy(IgnoreStrategy.builder().tenantLine(true).build(), block);
+    }
+
+    public static <T> T withIgnoreStrategy(IgnoreStrategy strategy, Supplier<T> block) {
+        try {
+            InterceptorIgnoreHelper.handle(strategy);
+            return block.get();
+        } finally {
+            InterceptorIgnoreHelper.clearIgnoreStrategy();
+        }
+    }
+}

--- a/wemirr-platform-iam/src/main/java/com/wemirr/platform/iam/system/service/impl/UserServiceImpl.java
+++ b/wemirr-platform-iam/src/main/java/com/wemirr/platform/iam/system/service/impl/UserServiceImpl.java
@@ -29,8 +29,6 @@ import cn.hutool.core.util.StrUtil;
 import com.alibaba.fastjson2.JSONObject;
 import com.baomidou.dynamic.datasource.annotation.DSTransactional;
 import com.baomidou.mybatisplus.core.metadata.IPage;
-import com.baomidou.mybatisplus.core.plugins.IgnoreStrategy;
-import com.baomidou.mybatisplus.core.plugins.InterceptorIgnoreHelper;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.wemirr.framework.commons.BeanUtilPlus;
 import com.wemirr.framework.commons.annotation.remote.RemoteResult;
@@ -44,6 +42,7 @@ import com.wemirr.framework.db.mybatisplus.wrap.Wraps;
 import com.wemirr.framework.db.mybatisplus.wrap.query.LbqWrapper;
 import com.wemirr.framework.db.properties.DatabaseProperties;
 import com.wemirr.framework.db.properties.MultiTenantType;
+import com.wemirr.framework.db.utils.InterceptorIgnoreUtils;
 import com.wemirr.framework.db.utils.TenantHelper;
 import com.wemirr.framework.log.diff.core.annotation.DiffLog;
 import com.wemirr.framework.log.diff.core.context.DiffLogContext;
@@ -194,11 +193,12 @@ public class UserServiceImpl extends SuperServiceImpl<UserMapper, User> implemen
     @Override
     public UserInfoDetails userinfo(Long userId) {
         // TODO 后续通过注解和 API 方式动态控制，MP3.5.10 支持 api.execute 方式
-        InterceptorIgnoreHelper.handle(IgnoreStrategy.builder().tenantLine(true).build());
-        final User user = Optional.ofNullable(this.baseMapper.selectById(userId))
-                .orElseThrow(() -> CheckedException.notFound("用户信息不存在"));
-        Tenant tenant = this.tenantMapper.selectById(user.getTenantId());
-        return userinfo(UserTenantAuthentication.builder().user(user).tenant(tenant).build());
+        return InterceptorIgnoreUtils.withIgnoreStrategy(() -> {
+            final User user = Optional.ofNullable(this.baseMapper.selectById(userId))
+                    .orElseThrow(() -> CheckedException.notFound("用户信息不存在"));
+            Tenant tenant = this.tenantMapper.selectById(user.getTenantId());
+            return userinfo(UserTenantAuthentication.builder().user(user).tenant(tenant).build());
+        });
     }
 
     @Override

--- a/wemirr-platform-suite/src/main/java/com/wemirr/platform/suite/file/event/StorageSettingTemplate.java
+++ b/wemirr-platform-suite/src/main/java/com/wemirr/platform/suite/file/event/StorageSettingTemplate.java
@@ -24,10 +24,9 @@ import cn.hutool.core.util.StrUtil;
 import cn.hutool.extra.spring.SpringUtil;
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONObject;
-import com.baomidou.mybatisplus.core.plugins.IgnoreStrategy;
-import com.baomidou.mybatisplus.core.plugins.InterceptorIgnoreHelper;
 import com.wemirr.framework.commons.security.AuthenticationContext;
 import com.wemirr.framework.db.mybatisplus.wrap.Wraps;
+import com.wemirr.framework.db.utils.InterceptorIgnoreUtils;
 import com.wemirr.platform.suite.file.domain.constants.StorageConstants;
 import com.wemirr.platform.suite.file.domain.entity.FileStorageSetting;
 import com.wemirr.platform.suite.file.repository.FileStorageSettingMapper;
@@ -48,16 +47,15 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class StorageSettingTemplate implements ApplicationRunner {
-    
+
     private final AuthenticationContext context;
     private final FileStorageSettingMapper fileStorageSettingMapper;
     private final RedisTemplate<String, Object> redisTemplate;
-    
+
     @Override
     public void run(ApplicationArguments args) {
         log.info("==================== 存储设置初始化-Begin ====================");
-        InterceptorIgnoreHelper.handle(IgnoreStrategy.builder().tenantLine(true).build());
-        List<FileStorageSetting> storageSettingList = fileStorageSettingMapper.selectList(FileStorageSetting::getStatus, true);
+        List<FileStorageSetting> storageSettingList = InterceptorIgnoreUtils.withIgnoreStrategy(() -> fileStorageSettingMapper.selectList(FileStorageSetting::getStatus, true));
         if (CollUtil.isEmpty(storageSettingList)) {
             return;
         }
@@ -66,7 +64,7 @@ public class StorageSettingTemplate implements ApplicationRunner {
         }
         log.info("==================== 存储设置初始化-End ====================");
     }
-    
+
     public void publish(FileStorageSetting setting, int eventType) {
         log.info("redis publish - {},type -> {}", setting, eventType);
         // 构建后台存储配置的平台名称（租户ID + 平台名称）
@@ -90,7 +88,7 @@ public class StorageSettingTemplate implements ApplicationRunner {
         redisTemplate.convertAndSend(StorageConstants.STORAGE_CONFIG_EVENT_TOPIC, event);
         SpringUtil.publishEvent(event);
     }
-    
+
     public FileStorageSetting getDefaultStorageSetting() {
         String json = (String) redisTemplate.opsForHash().get(StorageConstants.STORAGE_SETTING_DEFAULT_SETTING, context.tenantId().toString());
         if (StrUtil.isBlank(json)) {


### PR DESCRIPTION
- 新增 InterceptorIgnoreUtils工具类，用于简化租户策略忽略操作
- 在 StorageSettingTemplate 和 UserServiceImpl 中使用新工具类替换原有的手动忽略策略代码
- 通过函数式编程方式实现更简洁、更易于管理的租户策略忽略逻辑