### PR TITLE
fix(security): 将 StpInterfaceRedisImpl 移动到 security模块｜解决不是在iam服务无法正确获取权限的问题

### DIFF
--- a/wemirr-platform-framework/security-spring-boot-starter/src/main/java/com/wemirr/framework/security/configuration/StpInterfaceRedisImpl.java
+++ b/wemirr-platform-framework/security-spring-boot-starter/src/main/java/com/wemirr/framework/security/configuration/StpInterfaceRedisImpl.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-package com.wemirr.platform.iam.auth.listener;
+package com.wemirr.framework.security.configuration;
 
 import cn.dev33.satoken.stp.StpInterface;
 import com.wemirr.framework.commons.security.AuthenticationContext;

--- a/wemirr-platform-framework/security-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/wemirr-platform-framework/security-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 com.wemirr.framework.security.configuration.OAuth2AutoConfiguration
 com.wemirr.framework.security.configuration.OAuth2ExceptionHandler
+com.wemirr.framework.security.configuration.StpInterfaceRedisImpl


### PR DESCRIPTION
- 将 StpInterfaceRedisImpl 类从 iam 模块移动到 security-spring-boot-starter 模块
- 解决不是在iam服务无法正确获取权限的问题