### PR TITLE
  fix(cache): 修复DictLoaderService缓存刷新机制

### DIFF
--- a/wemirr-platform-framework/common-spring-boot-starter/src/main/java/com/wemirr/framework/boot/remote/dict/DictLoadService.java
+++ b/wemirr-platform-framework/common-spring-boot-starter/src/main/java/com/wemirr/framework/boot/remote/dict/DictLoadService.java
@@ -58,6 +58,7 @@ public class DictLoadService implements LoadService<Object> {
             return;
         }
         for (Map.Entry<String, List<Pair<String, String>>> entry : data.entrySet()) {
+            redisTemplate.opsForHash().delete(PLAT_DICT_HASH_KEY, entry.getKey());
             String key = entry.getKey();
             List<Pair<String, String>> value = entry.getValue();
             if (value == null) {

--- a/wemirr-plugin/wemirr-platform-bpm/src/main/java/com/wemirr/platform/bpm/service/impl/ProcessModelServiceImpl.java
+++ b/wemirr-plugin/wemirr-platform-bpm/src/main/java/com/wemirr/platform/bpm/service/impl/ProcessModelServiceImpl.java
@@ -91,8 +91,7 @@ public class ProcessModelServiceImpl extends SuperServiceImpl<ProcessModelMapper
     public void modify(Long id, DesignModelSaveReq req) {
         ProcessCategory category = Optional.ofNullable(this.processCategoryMapper.selectById(req.getCategoryId())).orElseThrow(() -> CheckedException.notFound("流程类型不存在"));
         final Long count = this.baseMapper.selectCount(Wraps.<ProcessModel>lbQ().ne(ProcessModel::getId, id)
-                .eq(ProcessModel::getDefinitionKey, req.getDefinitionKey())
-                .eq(ProcessModel::getTenantId, context.tenantId()));
+                .eq(ProcessModel::getDefinitionKey, req.getDefinitionKey()));
         if (count != null && count > 0) {
             throw CheckedException.badRequest("bpm.design.duplicate-process-key");
         }


### PR DESCRIPTION
  - 优化refresh()方法：采用先删除后新增策略替代PUT操作
  - 解决Redis缓存更新不生效导致的数据不一致问题
  - 确保服务重启时缓存能够正确刷新和替换

  Note: 建议优化ProcessModel查询方法，避免手动添加tenantId条件的冗余操作